### PR TITLE
Use `pyproject.toml` for setuptools and make Cython required.

### DIFF
--- a/.github/workflows/build-python-dists.yml
+++ b/.github/workflows/build-python-dists.yml
@@ -31,11 +31,9 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --progress-bar off --upgrade pip setuptools
-          pip install numpy scikit-learn "Cython>=3.0.0a10"
 
       - name: Build sdist
         run: |
-          python setup.py build_ext --inplace
           python setup.py sdist
 
       - name: Upload a sdist package to a GitHub release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "optuna-fast-fanova"
 description = "Cython accelerated fANOVA implementation for Optuna"
+readme = "README.md"
 authors = [
   { name = "Masashi Shibata", "email" = "mshibata@preferred.jp" }
 ]
@@ -33,11 +34,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dynamic = ["version", "readme"]
+dynamic = ["version"]
 
 [tool.setuptools.dynamic]
 version = {attr = "optuna_fast_fanova.__version__"}
-readme = {file = ["README.md"]}
 
 [tool.black]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,44 @@
+[build-system]
+requires = ["setuptools>=61", "numpy", "scikit-learn", "Cython>=3.0.0a10"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "optuna-fast-fanova"
+description = "Cython accelerated fANOVA implementation for Optuna"
+authors = [
+  { name = "Masashi Shibata", "email" = "mshibata@preferred.jp" }
+]
+requires-python = ">=3.6"
+dependencies = [
+    "optuna",
+    "numpy",
+    "scikit-learn",
+]
+license = {text = "MIT License"}
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dynamic = ["version", "readme"]
+
+[tool.setuptools.dynamic]
+version = {attr = "optuna_fast_fanova.__version__"}
+readme = {file = ["README.md"]}
+
 [tool.black]
 line-length = 99
 target-version = ['py39']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ dynamic = ["version"]
 [tool.setuptools.dynamic]
 version = {attr = "optuna_fast_fanova.__version__"}
 
+[project.urls]
+"Sources" = "https://github.com/optuna/optuna-fast-fanova"
+"Bug Tracker" = "https://github.com/optuna/optuna-fast-fanova/issues"
+
 [tool.black]
 line-length = 99
 target-version = ['py39']

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,16 @@ from setuptools import setup
 if __name__ == "__main__":
     setup(
         packages=find_packages(exclude=("tests", "tests.*")),
-        ext_modules=cythonize([
-            Extension(
-                "optuna_fast_fanova._fanova",
-                sources=[os.path.join("optuna_fast_fanova", "_fanova.pyx")],
-                include_dirs=[numpy.get_include()],
-                language="c",
-            )
-        ]),
+        ext_modules=cythonize(
+            [
+                Extension(
+                    "optuna_fast_fanova._fanova",
+                    sources=[os.path.join("optuna_fast_fanova", "_fanova.pyx")],
+                    include_dirs=[numpy.get_include()],
+                    language="c",
+                )
+            ]
+        ),
         include_package_data=False,
         package_data={"optuna_fast_fanova": ["*.pyx"]},
     )

--- a/setup.py
+++ b/setup.py
@@ -20,37 +20,8 @@ class LazyImportBuildExt(build_ext):
         super().run()
 
 
-def get_long_description() -> str:
-    readme_filepath = os.path.join(os.path.dirname(__file__), "README.md")
-    with open(readme_filepath) as f:
-        return f.read()
-
-
-def get_version() -> str:
-    version_filepath = os.path.join(os.path.dirname(__file__), "optuna_fast_fanova", "__init__.py")
-    with open(version_filepath) as f:
-        for line in f:
-            if line.startswith("__version__"):
-                return line.strip().split()[-1][1:-1]
-    assert False, "must not reach here"
-
-
 if __name__ == "__main__":
     setup(
-        name="optuna-fast-fanova",
-        version=get_version(),
-        description="Cython accelerated fANOVA implementation for Optuna",
-        long_description=get_long_description(),
-        long_description_content_type="text/markdown",
-        author="Masashi Shibata",
-        author_email="mshibata@preferred.jp",
-        project_urls={
-            "Source": "https://github.com/optuna/optuna-fast-fanova",
-            "Bug Tracker": "https://github.com/optuna/optuna-fast-fanova/issues",
-        },
-        # You need to install Cython when building this package from sources.
-        setup_requires=["numpy", "scikit-learn", "Cython>=3.0.0a10"],
-        install_requires=["optuna"],
         packages=find_packages(exclude=("tests", "tests.*")),
         ext_modules=[
             Extension(
@@ -62,22 +33,4 @@ if __name__ == "__main__":
         cmdclass={"build_ext": LazyImportBuildExt},
         include_package_data=False,
         package_data={"optuna_fast_fanova": ["*.pyx"]},
-        classifiers=[
-            "Development Status :: 2 - Pre-Alpha",
-            "Intended Audience :: Science/Research",
-            "Intended Audience :: Developers",
-            "License :: OSI Approved :: MIT License",
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3 :: Only",
-            "Topic :: Scientific/Engineering",
-            "Topic :: Scientific/Engineering :: Mathematics",
-            "Topic :: Scientific/Engineering :: Artificial Intelligence",
-            "Topic :: Software Development",
-            "Topic :: Software Development :: Libraries",
-            "Topic :: Software Development :: Libraries :: Python Modules",
-        ],
     )

--- a/setup.py
+++ b/setup.py
@@ -6,20 +6,11 @@ from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
 
-try:
-    from Cython.Build import cythonize
-
-    ext = ".pyx"
-except ImportError:
-    cythonize = None
-    ext = ".c"
-
-
 class LazyImportBuildExt(build_ext):
     def finalize_options(self) -> None:
-        # cythoinze() must be lazily called since Cython's build requires scikit-learn.
-        if cythonize is not None:
-            self.extensions = cythonize(self.extensions)
+        from Cython.Build import cythonize
+
+        self.extensions = cythonize(self.extensions)
         super().finalize_options()
 
     def run(self) -> None:
@@ -58,19 +49,19 @@ if __name__ == "__main__":
             "Bug Tracker": "https://github.com/optuna/optuna-fast-fanova/issues",
         },
         # You need to install Cython when building this package from sources.
-        setup_requires=["numpy", "scikit-learn"],
+        setup_requires=["numpy", "scikit-learn", "Cython>=3.0.0a10"],
         install_requires=["optuna"],
         packages=find_packages(exclude=("tests", "tests.*")),
         ext_modules=[
             Extension(
                 "optuna_fast_fanova._fanova",
-                sources=[os.path.join("optuna_fast_fanova", "_fanova" + ext)],
+                sources=[os.path.join("optuna_fast_fanova", "_fanova.pyx")],
                 language="c",
             )
         ],
         cmdclass={"build_ext": LazyImportBuildExt},
         include_package_data=False,
-        package_data={"optuna_fast_fanova": ["*.c", "*.pyx"]},
+        package_data={"optuna_fast_fanova": ["*.pyx"]},
         classifiers=[
             "Development Status :: 2 - Pre-Alpha",
             "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,23 @@
 import os
 
+from Cython.Build import cythonize
+import numpy
 from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup
-from setuptools.command.build_ext import build_ext
-
-
-class LazyImportBuildExt(build_ext):
-    def finalize_options(self) -> None:
-        from Cython.Build import cythonize
-
-        self.extensions = cythonize(self.extensions)
-        super().finalize_options()
-
-    def run(self) -> None:
-        import numpy
-
-        self.include_dirs.append(numpy.get_include())
-        super().run()
 
 
 if __name__ == "__main__":
     setup(
         packages=find_packages(exclude=("tests", "tests.*")),
-        ext_modules=[
+        ext_modules=cythonize([
             Extension(
                 "optuna_fast_fanova._fanova",
                 sources=[os.path.join("optuna_fast_fanova", "_fanova.pyx")],
+                include_dirs=[numpy.get_include()],
                 language="c",
             )
-        ],
-        cmdclass={"build_ext": LazyImportBuildExt},
+        ]),
         include_package_data=False,
         package_data={"optuna_fast_fanova": ["*.pyx"]},
     )


### PR DESCRIPTION
## Motivation

Fixes #6.

As reported in #6, scikit-learn's C-API (Cython pxd file) is available to users, but many ABI changes have actually been made. optuna-fast-fanova contains a C extension file generated in Cython using scikit-learn v1.1.1, but scikit-learn v1.1.2 has the following changes to the ClassificationCriterion cdef class Therefore, it does not seem to be compatible with scikit-learn v1.1.2.
https://github.com/scikit-learn/scikit-learn/pull/22921

## Changes

Previously, the C extension file was included in the sdist package so that users without Cython could install optuna-fast-fanova. This approach is recommended at [Cython documentation](http://docs.cython.org/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules). However, as I described above, it is almost impossible to keep scikit-learn's ABI compatibility.
In this PR, I added a Cython dependency to setup_requires to generate a C extension file for each installation.

Furthermore, I move the project-metadata and build-system requirements to pyproject.toml since `setup_requires` is deprecated and `build-system.requires` is recommended option.
https://pip.pypa.io/en/stable/reference/build-system/index.html#controlling-setup-requires