### PR TITLE
Use MANIFEST.in to exclude files from the source package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.pyx
+exclude tools/*
+exclude tests/*
+exclude .github/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "numpy",
     "scikit-learn",
 ]
-license = {text = "MIT License"}
+license = { text = "MIT License" }
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
@@ -35,6 +35,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dynamic = ["version"]
+
+[tool.setuptools.packages.find]
+where = ["."]
 
 [tool.setuptools_scm]
 write_to = "optuna_fast_fanova/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,11 @@ import os
 import Cython.Build
 import numpy
 from setuptools import Extension
-from setuptools import find_packages
 from setuptools import setup
 
 
 if __name__ == "__main__":
     setup(
-        packages=find_packages(exclude=("tests", "tests.*", "example*")),
         ext_modules=[
             Extension(
                 "optuna_fast_fanova._fanova",
@@ -19,6 +17,5 @@ if __name__ == "__main__":
             )
         ],
         cmdclass={"build_ext": Cython.Build.build_ext},
-        include_package_data=False,
         package_data={"optuna_fast_fanova": ["*.pyx"]},
     )


### PR DESCRIPTION
> File finders hook makes most of MANIFEST.in unnecessary
> setuptools_scm implements a [file_finders](https://setuptools.pypa.io/en/latest/userguide/extension.html#adding-support-for-revision-control-systems) entry point which returns all files tracked by your SCM. This eliminates the need for a manually constructed MANIFEST.in in most cases where this would be required when not using setuptools_scm, namely:
>
> To ensure all relevant files are packaged when running the sdist command.
> When using [include_package_data](https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files) to include package data as part of the build or bdist_wheel.
> MANIFEST.in may still be used: anything defined there overrides the hook. This is mostly useful to exclude files tracked in your SCM from packages, although in principle it can be used to explicitly include non-tracked files too.
> https://github.com/pypa/setuptools_scm