### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [
   { name = "Masashi Shibata", "email" = "mshibata@preferred.jp" }
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
     "optuna",
     "numpy",


### PR DESCRIPTION
Because `setuptools>=61` does not support Python 3.6.