### PR TITLE
Avoid to use numpy.int

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/python-tests.yml'
       - 'pyproject.toml'
       - '**.py'
+      - '**.pyx'
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/optuna_fast_fanova/_fanova.pyx
+++ b/optuna_fast_fanova/_fanova.pyx
@@ -85,7 +85,7 @@ cdef class FanovaTree:
         sample = np.full(self._n_features, fill_value=np.nan, dtype=np.float64)
         active_features = np.zeros_like(np.asarray(sample), dtype=np.bool_)
 
-        active_nodes_buf = np.empty(shape=self._tree.node_count, dtype=np.int)
+        active_nodes_buf = np.empty(shape=self._tree.node_count, dtype=np.int64)
         active_search_spaces_buf = np.empty(shape=(self._tree.node_count, self._search_spaces.shape[0], 2), dtype=np.float64)
 
         values = np.empty(shape=n_loop, dtype=np.float64)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/tmp/ipykernel_332/981997251.py", line 21, in _get_param_importances
    return get_param_importances(
  File "/usr/local/lib/python3.9/site-packages/optuna/importance/__init__.py", line 103, in get_param_importances
    res = evaluator.evaluate(study, params=params, target=target)
  File "/usr/local/lib/python3.9/site-packages/optuna_fast_fanova/_evaluator.py", line 114, in evaluate
    importances = compute_importance(self._forest, trans, distributions.keys())
  File "/usr/local/lib/python3.9/site-packages/optuna_fast_fanova/_evaluator.py", line 150, in compute_importance
    marginal_variance = tree.get_marginal_variance(raw_feature)
  File "optuna_fast_fanova/_fanova.pyx", line 88, in optuna_fast_fanova._fanova.FanovaTree.get_marginal_variance
  File "/usr/local/lib/python3.9/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'int'
```

Refs https://github.com/optuna/optuna-examples/pull/154